### PR TITLE
fix: remove stale root dividend deduction from subnet APY

### DIFF
--- a/src/subnet_calc.py
+++ b/src/subnet_calc.py
@@ -14,47 +14,39 @@ from helpers import (
     get_parents,
     get_stake_for_hotkey_on_subnet,   # netuid!=0 -> alpha stake; netuid==0 -> tao stake (root)
     get_tao_weight,
-    get_root_claimable_entries,       # returns dict {netuid: alpha_per_tao} (cumulative rate)
 )
 
 
 def calculate_hotkey_subnet_apy(
     events: List[Dict],
     results: List[dict],
-    baseline_root_claimable_alpha_per_tao: float,
     actual_interval_seconds: float,
     no_filters: bool = False,
-) -> Tuple[float, float, float, int, float]:
+) -> Tuple[float, float, float, int]:
     """
     Calculate APY for a hotkey on a subnet from fetched data.
-    
-    This function contains only calculation logic - all data must be provided as arguments.
-    No async operations or external queries are performed.
-    
+
+    Since subtensor v3.3.0 (spec 361), AlphaDividendsPerSubnet contains only
+    pure subnet alpha dividends. Root-originated dividends are now tracked
+    separately in RootAlphaDividendsPerSubnet on-chain, so no deduction is
+    needed here.
+
     Args:
         events: List of event dicts with keys: block, netuid, tempo
         results: List of fetched data dicts (one per event), or -1 for failed queries
-        baseline_root_claimable_alpha_per_tao: Baseline root claimable α/TAO for this netuid at start_block - 1
         actual_interval_seconds: Actual interval duration in seconds (for APY calculation)
         no_filters: If False, apply stake filters to guard noisy events
-    
+
     Returns:
-        Tuple[float, float, float, int, float]: (apy_percent, alpha_only_divs_sum_alpha, period_yield, skipped, total_divs_sum_alpha)
+        Tuple[float, float, float, int]: (apy_percent, divs_sum_alpha, period_yield, skipped)
     """
-    total_divs_sum_alpha = 0.0        # raw AlphaDividendsPerSubnet (alpha)
-    alpha_only_divs_sum_alpha = 0.0   # after root deduction (alpha)
+    divs_sum_alpha = 0.0
     yield_product = 1.0
     skipped = 0
-
-    # Track previous root claimable alpha per tao for delta calculation
-    prev_alpha_per_tao = float(baseline_root_claimable_alpha_per_tao)
 
     for event_index, _ in enumerate(events):
         data = results[event_index]
         if data == -1:
-            # Query failed - we don't have claimable value, so we can't update prev_alpha_per_tao
-            # This means the next epoch will calculate delta from the wrong baseline
-            # This is unavoidable when queries fail, but we should still track it
             skipped += 1
             continue
 
@@ -64,59 +56,34 @@ def calculate_hotkey_subnet_apy(
         inh_subnet_stake   = data["inh_subnet_stake"]
         tao_weight_param   = data["tao_weight_param"]
         alpha_div_raw      = data["alpha_div_raw"]
-        root_claimable_alpha_per_tao = data["root_claimable_alpha_per_tao"]  # Current value at this block
-
-        # Calculate delta: current - previous
-        curr_alpha_per_tao = float(root_claimable_alpha_per_tao)
-        d_alpha_per_tao = curr_alpha_per_tao - prev_alpha_per_tao
-        if d_alpha_per_tao < 0:
-            d_alpha_per_tao = 0.0  # clamp negative deltas
-
-        # IMPORTANT: Update baseline for next observation BEFORE any skip conditions
-        # This ensures that even if we skip this epoch for yield calculation,
-        # the claimable progression is still tracked correctly for delta calculations
-        prev_alpha_per_tao = curr_alpha_per_tao
 
         if alpha_div_raw == 0:
-            # Skip yield calculation but claimable was already updated above - correct
             continue
 
-        # Apply filter as before (guards noisy/minuscule stake epochs)
+        # Apply filter (guards noisy/minuscule stake epochs)
         if not no_filters and not has_enough_stake(
             root_stake_tao, subnet_alpha_stake, inh_root_stake, inh_subnet_stake, tao_weight_param
         ):
-            # Skip yield calculation but claimable was already updated above - correct
             skipped += 1
             continue
 
-        # Root-directed component in *alpha* for this epoch:
-        #   root_alpha = dRC(α/tao) * root_stake_tao(tao)
-        root_alpha_component = d_alpha_per_tao * root_stake_tao
-        if root_alpha_component < 0:
-            root_alpha_component = 0.0
-
-        # Deduct root-directed alpha from the raw credited alpha
-        alpha_only_div = alpha_div_raw - root_alpha_component
-        if alpha_only_div < 0:
-            alpha_only_div = 0.0
-
-        # Denominator is *alpha* stake on the subnet
+        # AlphaDividendsPerSubnet now contains only pure subnet alpha dividends
+        # (root dividends moved to RootAlphaDividendsPerSubnet in subtensor v3.3.0-361)
         denom = subnet_alpha_stake
         if denom <= 0:
             skipped += 1
             continue
 
-        epoch_yield = alpha_only_div / denom
+        epoch_yield = alpha_div_raw / denom
 
-        alpha_only_divs_sum_alpha += alpha_only_div
-        total_divs_sum_alpha      += alpha_div_raw
-        yield_product             *= (1.0 + epoch_yield)
+        divs_sum_alpha  += alpha_div_raw
+        yield_product   *= (1.0 + epoch_yield)
 
     period_yield = yield_product - 1.0
     compounding_periods = INTERVAL_SECONDS["year"] / actual_interval_seconds
     apy_percent = calculate_apy(period_yield, compounding_periods)
 
-    return apy_percent, alpha_only_divs_sum_alpha, period_yield, skipped, total_divs_sum_alpha
+    return apy_percent, divs_sum_alpha, period_yield, skipped
 
 
 async def retrieve_and_calculate_hotkey_subnet_apy(
@@ -131,51 +98,46 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
     no_filters: bool = False,
 ) -> Tuple[float, float]:
     """
-    Subnet APY for a hotkey, with root-directed share deducted in *alpha* units.
+    Subnet APY for a hotkey.
 
     For each epoch boundary at block B:
       alpha_div_raw          = AlphaDividendsPerSubnet[netuid, hotkey]   (alpha)
-      dRC_alpha_per_tao      = max(0, RC[hotkey][netuid]_B - RC[hotkey][netuid]_{B-1})
-      root_stake_tao         = TotalHotkeyAlpha[hotkey, 0]               (tao on root)
-      root_alpha_component   = dRC_alpha_per_tao * root_stake_tao        (alpha)
-      alpha_only_div         = max(0, alpha_div_raw - root_alpha_component) (alpha)
       subnet_alpha_stake     = TotalHotkeyAlpha[hotkey, netuid]          (alpha)
-      epoch_yield            = alpha_only_div / subnet_alpha_stake        (dimensionless)
+      epoch_yield            = alpha_div_raw / subnet_alpha_stake         (dimensionless)
 
-    Notes:
-      * No price conversion is needed; everything subtracted/compared is in alpha units.
-      * We keep the existing has_enough_stake(...) filter to guard noisy events.
+    Since subtensor v3.3.0 (spec 361), AlphaDividendsPerSubnet no longer
+    includes root-originated dividends, so no root deduction is required.
     """
 
     if netuid == 0:
         raise Exception('For root network use calculate_hotkey_root_apy() instead')
-    
+
     subnet = await subtensor.subnet(netuid, block)
     tempo = subnet.tempo
     last_epoch_block = subnet.last_step
 
     interval_blocks = calculate_interval_blocks(tempo, interval)
-    
+
     # Calculate the actual interval using INTERVAL_SECONDS (like root_calc.py)
     interval_seconds = INTERVAL_SECONDS[interval]
     actual_interval_blocks = int(interval_seconds / BLOCK_SECONDS)
     actual_interval_seconds = actual_interval_blocks * BLOCK_SECONDS
-    
+
     # FIX: Use exactly N epochs to ensure consistent event count
     # Calculate expected number of epochs for this interval (floor division)
     period = tempo + 1
     expected_epochs = actual_interval_blocks // period  # Floor division to get whole epochs
     if expected_epochs < 1:
         expected_epochs = 1  # At least 1 epoch
-    
+
     # Use exactly expected_epochs epochs as the window
     # Start from last_epoch_block and go back (expected_epochs - 1) epochs
     # This ensures we always get exactly expected_epochs events
     start_block = last_epoch_block - (expected_epochs - 1) * period
-    
+
     # Build list of epoch boundary blocks WITHIN the calculation window
     # Collect exactly expected_epochs events in reverse chronological order (newest first)
-    # Then reverse to chronological (oldest first) for correct delta calculation
+    # Then reverse to chronological (oldest first)
     events: List[Dict] = []
     epoch = last_epoch_block
     for _ in range(expected_epochs):
@@ -183,8 +145,8 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
         epoch -= period
         if epoch < start_block:
             break  # Safety check
-    
-    # Reverse to chronological order (oldest first) for correct delta calculation
+
+    # Reverse to chronological order (oldest first)
     events.reverse()
 
     data_task = progress.add_task(f"[cyan]Fetching data for {hotkey}", total=len(events))
@@ -193,9 +155,8 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
         """
         Fetch all data for one epoch boundary:
           - tao_weight (for filter)
-          - subnet_alpha_stake (alpha), root_stake_tao (tao on root)
+          - subnet_alpha_stake (alpha), root_stake_tao (tao on root, for filter)
           - alpha_div_raw (alpha) from AlphaDividendsPerSubnet
-          - RootClaimable at current block (alpha/tao) for this hotkey
           - inherited stakes (optional)
         """
         try:
@@ -204,13 +165,11 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
                 subnet_alpha_stake,
                 root_stake_tao,
                 alpha_div_raw,
-                rc_curr_map,
             ) = await asyncio.gather(
                 get_tao_weight(subtensor, event_block),
                 get_stake_for_hotkey_on_subnet(subtensor, hotkey, netuid, event_block),
                 get_stake_for_hotkey_on_subnet(subtensor, hotkey, 0, event_block),
                 get_divs_for_hotkey_on_subnet(subtensor, hotkey, netuid, event_block),
-                get_root_claimable_entries(subtensor, hotkey, event_block),
             )
 
             inh_root_stake = 0.0
@@ -225,38 +184,20 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
                     calc_inherited_on_subnet(subtensor, subnet_alpha_stake, netuid, parents, children, event_block),
                 )
 
-            # Extract root claimable alpha per tao for this netuid at current block
-            root_claimable_alpha_per_tao = float((rc_curr_map or {}).get(netuid, 0.0))
-
             progress.update(data_task, advance=1)
 
             return {
                 "block": event_block,
                 "tao_weight_param": tao_weight_param,
-                "alpha_div_raw": alpha_div_raw,                      # alpha
-                "root_stake_tao": root_stake_tao,                    # tao
-                "subnet_alpha_stake": subnet_alpha_stake,            # alpha
+                "alpha_div_raw": alpha_div_raw,
+                "root_stake_tao": root_stake_tao,
+                "subnet_alpha_stake": subnet_alpha_stake,
                 "inh_root_stake": inh_root_stake,
                 "inh_subnet_stake": inh_subnet_stake,
-                "root_claimable_alpha_per_tao": root_claimable_alpha_per_tao,  # alpha / tao at current block
             }
         except Exception as e:
             progress.update(data_task, advance=1)
             return -1
-
-    # Fetch baseline root claimable at one epoch before the first (oldest) event in the interval
-    # This ensures we can calculate the delta for the first event correctly
-    if len(events) > 0:
-        first_event_block = events[0]["block"]  # Oldest event (first in chronological order)
-        baseline_block = max(first_event_block - period, 1)
-    else:
-        # Fallback: use start_block - period if no events
-        baseline_block = max(start_block - period, 1)
-    baseline_root_claimable_map = await get_root_claimable_entries(subtensor, hotkey, baseline_block)
-    if baseline_root_claimable_map is None:
-        baseline_root_claimable_map = {}
-    # Extract value for this specific netuid
-    baseline_root_claimable_alpha_per_tao = float(baseline_root_claimable_map.get(netuid, 0.0))
 
     # Batch fetch
     data_tasks = [lambda event=event: query_data_with_progress(event["block"], hotkey, netuid) for event in events]
@@ -268,10 +209,9 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
         results.extend([-1 if isinstance(r, Exception) else r for r in batch_results])
 
     # ------------------------ Calculation ------------------------
-    apy_percent, alpha_only_divs_sum_alpha, period_yield, skipped, total_divs_sum_alpha = calculate_hotkey_subnet_apy(
+    apy_percent, divs_sum_alpha, period_yield, skipped = calculate_hotkey_subnet_apy(
         events=events,
         results=results,
-        baseline_root_claimable_alpha_per_tao=baseline_root_claimable_alpha_per_tao,
         actual_interval_seconds=actual_interval_seconds,
         no_filters=no_filters,
     )
@@ -285,9 +225,8 @@ async def retrieve_and_calculate_hotkey_subnet_apy(
                 f"[yellow]Coverage is less than: {REQUIRED_BLOCKS_RATIO * 100:.6f}% and can lead to inaccurate results.[/yellow]"
             )
 
-    progress.console.print(f"{interval} percentage yield (alpha-only base): {period_yield * 100:.6f}%")
-    progress.console.print(f"{interval} total raw subnet divs [alpha]: {total_divs_sum_alpha:.6f}")
-    progress.console.print(f"{interval} alpha-only dividends (after root deduction) [alpha]: {alpha_only_divs_sum_alpha:.6f}")
+    progress.console.print(f"{interval} percentage yield: {period_yield * 100:.6f}%")
+    progress.console.print(f"{interval} subnet divs [alpha]: {divs_sum_alpha:.6f}")
     progress.console.print(f"apy: {apy_percent:.6f}%")
 
-    return apy_percent, alpha_only_divs_sum_alpha
+    return apy_percent, divs_sum_alpha

--- a/tests/data/calc_args_subnet_20251117_103000.json
+++ b/tests/data/calc_args_subnet_20251117_103000.json
@@ -1,31 +1,280 @@
 {
   "events": [
     {
-      "block": 6892159,
-      "netuid": 51,
+      "block": 7896448,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7896809,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7897170,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7897531,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7897892,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7898253,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7898614,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7898975,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7899336,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7899697,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7900058,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7900419,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7900780,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7901141,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7901502,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7901863,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7902224,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7902585,
+      "netuid": 64,
+      "tempo": 360
+    },
+    {
+      "block": 7902946,
+      "netuid": 64,
       "tempo": 360
     }
   ],
   "fetched_data": [
     {
-      "block": 6892159,
+      "block": 7896448,
       "tao_weight_param": 0.18,
-      "alpha_div_raw": 1.485580126,
-      "root_stake_tao": 240446.50948337,
-      "subnet_alpha_stake": 2375.40855654,
+      "alpha_div_raw": 49.583898701,
+      "root_stake_tao": 344.044077524,
+      "subnet_alpha_stake": 883116.647690069,
       "inh_root_stake": 0.0,
-      "inh_subnet_stake": 0.0,
-      "root_claimable_alpha_per_tao": 0.0011454860214143991
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7896809,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.591532381,
+      "root_stake_tao": 344.044077524,
+      "subnet_alpha_stake": 883383.597302082,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7897170,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.586011678,
+      "root_stake_tao": 344.044077524,
+      "subnet_alpha_stake": 883626.363612932,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7897531,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.586726741,
+      "root_stake_tao": 344.044077524,
+      "subnet_alpha_stake": 883709.775775052,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7897892,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.578603346,
+      "root_stake_tao": 344.044077524,
+      "subnet_alpha_stake": 883678.133552406,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7898253,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.62800463,
+      "root_stake_tao": 344.044163527,
+      "subnet_alpha_stake": 885890.14859281,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7898614,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.669174323,
+      "root_stake_tao": 344.044163527,
+      "subnet_alpha_stake": 886078.115251025,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7898975,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.701621711,
+      "root_stake_tao": 344.044163527,
+      "subnet_alpha_stake": 887283.225566604,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7899336,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.695444347,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887348.142574243,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7899697,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.692152355,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887415.6662073,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7900058,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.676557563,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887086.13460628,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7900419,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.668811614,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887208.841927666,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7900780,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.708886496,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887195.879174841,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7901141,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.617508137,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887058.662902197,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7901502,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.607743918,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887143.238450736,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7901863,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.590396543,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 886949.243813397,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7902224,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.585038182,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887096.405543951,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7902585,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.523757363,
+      "root_stake_tao": 344.044280171,
+      "subnet_alpha_stake": 887588.134865675,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
+    },
+    {
+      "block": 7902946,
+      "tao_weight_param": 0.18,
+      "alpha_div_raw": 49.522661892,
+      "root_stake_tao": 344.045244052,
+      "subnet_alpha_stake": 887678.391917855,
+      "inh_root_stake": 0.0,
+      "inh_subnet_stake": 0.0
     }
   ],
-  "baseline_root_claimable_alpha_per_tao": 0.001140126958489418,
-  "actual_interval_seconds": 4332.0,
+  "actual_interval_seconds": 86400.0,
   "no_filters": false,
   "results": {
-    "apy_percent": 82.89587346742617,
-    "alpha_only_divs_sum_alpha": 0.19701215158655105,
-    "period_yield": 8.293821753069253e-05,
-    "skipped": 0,
-    "total_divs_sum_alpha": 1.485580126
+    "apy_percent": 47.45269712656304,
+    "divs_sum_alpha": 942.8145319209998,
+    "period_yield": 0.0010645038287637743,
+    "skipped": 0
   }
 }

--- a/tests/test_subnet_calc_tao5.py
+++ b/tests/test_subnet_calc_tao5.py
@@ -16,20 +16,19 @@ def test_calculate_hotkey_subnet_apy_tao5():
     """Test calculate_hotkey_subnet_apy with real data from calc_args_subnet_20251117_103000.json"""
     # Load test data from JSON file
     json_file = Path(__file__).parent / "data" / "calc_args_subnet_20251117_103000.json"
-    
+
     if not json_file.exists():
         pytest.skip(f"Test data file not found: {json_file}")
-    
+
     with open(json_file, "r") as f:
         test_data = json.load(f)
-    
+
     # Extract inputs and ensure correct types
     events = test_data["events"]
     fetched_data = test_data["fetched_data"]  # This is the 'results' parameter
-    baseline_root_claimable_alpha_per_tao = float(test_data["baseline_root_claimable_alpha_per_tao"])
     actual_interval_seconds = float(test_data["actual_interval_seconds"])
     no_filters = bool(test_data["no_filters"])
-    
+
     # Convert fetched_data to ensure proper types
     # fetched_data can contain dicts or -1 for failed queries
     results = []
@@ -47,42 +46,36 @@ def test_calculate_hotkey_subnet_apy_tao5():
             results.append(converted)
         else:
             results.append(item)
-    
+
     # Extract expected results
     expected_results = test_data["results"]
     expected_apy_percent = expected_results["apy_percent"]
-    expected_alpha_only_divs_sum_alpha = expected_results["alpha_only_divs_sum_alpha"]
+    expected_divs_sum_alpha = expected_results["divs_sum_alpha"]
     expected_period_yield = expected_results["period_yield"]
     expected_skipped = expected_results["skipped"]
-    expected_total_divs_sum_alpha = expected_results["total_divs_sum_alpha"]
-    
+
     # Run calculation
-    apy_percent, alpha_only_divs_sum_alpha, period_yield, skipped, total_divs_sum_alpha = calculate_hotkey_subnet_apy(
+    apy_percent, divs_sum_alpha, period_yield, skipped = calculate_hotkey_subnet_apy(
         events=events,
         results=results,
-        baseline_root_claimable_alpha_per_tao=baseline_root_claimable_alpha_per_tao,
         actual_interval_seconds=actual_interval_seconds,
         no_filters=no_filters,
     )
-    
+
     # Assert results match expected values
     # Use epsilon for floating point comparison (0.000001 precision)
     assert abs(apy_percent - expected_apy_percent) < 0.000001, (
         f"APY percent mismatch: expected {expected_apy_percent}, got {apy_percent}"
     )
-    
-    assert abs(alpha_only_divs_sum_alpha - expected_alpha_only_divs_sum_alpha) < 0.000001, (
-        f"Alpha-only divs sum alpha mismatch: expected {expected_alpha_only_divs_sum_alpha}, got {alpha_only_divs_sum_alpha}"
+
+    assert abs(divs_sum_alpha - expected_divs_sum_alpha) < 0.000001, (
+        f"Divs sum alpha mismatch: expected {expected_divs_sum_alpha}, got {divs_sum_alpha}"
     )
-    
+
     assert abs(period_yield - expected_period_yield) < 0.000001, (
         f"Period yield mismatch: expected {expected_period_yield}, got {period_yield}"
     )
-    
+
     assert skipped == expected_skipped, (
         f"Skipped count mismatch: expected {expected_skipped}, got {skipped}"
-    )
-    
-    assert abs(total_divs_sum_alpha - expected_total_divs_sum_alpha) < 0.000001, (
-        f"Total divs sum alpha mismatch: expected {expected_total_divs_sum_alpha}, got {total_divs_sum_alpha}"
     )


### PR DESCRIPTION
## Summary

Since subtensor v3.3.0 (spec 361, enacted ~Dec 11 2025), `AlphaDividendsPerSubnet` no longer includes root-originated dividends — they are now stored separately in `RootAlphaDividendsPerSubnet` ([opentensor/subtensor#2218](https://github.com/opentensor/subtensor/pull/2218)).

The current code estimates and subtracts a root component from `AlphaDividendsPerSubnet` via `RootClaimable` delta tracking. This was correct before the chain change, but now produces **understated subnet APYs** because it deducts a phantom root share that is no longer present in the storage map.

### Impact

Tested on subnet 64 top-10 validators (24h APY):

| Validator | Root TAO | Old APY | New APY | **Δ APY** |
|-----------|----------|---------|---------|-----------|
| `5E2LP6EnZ54m...` | 920,998 | 24.30% | 47.39% | **+23.10%** |
| `5G9hfkx9wGB1...` | 49,522 | 33.67% | 47.22% | **+13.55%** |
| `5Dt7HZ7Zpw4D...` | 344 | 47.48% | 47.48% | +0.00% |
| Validators w/ 0 root TAO | 0 | identical | identical | 0.00% |

Validators with large root TAO stakes relative to their subnet alpha are most affected — up to **23 percentage points** of APY underreporting. Validators with zero root TAO are unaffected (results are identical).

### Changes

- Remove `get_root_claimable_entries` import and all baseline/per-epoch RPC calls
- Remove root claimable delta tracking and `root_alpha_component` deduction from `calculate_hotkey_subnet_apy()`
- Use `alpha_div_raw` directly as the subnet dividend
- Keep `root_stake_tao` fetch for the `has_enough_stake()` filter (still needed)
- Update test and fixture data to match new interface and expected values

### References

- Chain change: [opentensor/subtensor#2218](https://github.com/opentensor/subtensor/pull/2218) ("Root claim upgrade part 1")
- Release: [v3.3.0-361](https://github.com/opentensor/subtensor/releases/tag/v3.3.0-361) (Dec 9 2025)
- Current mainnet code: [`run_coinbase.rs:582-637`](https://github.com/opentensor/subtensor/blob/main/pallets/subtensor/src/coinbase/run_coinbase.rs#L582-L637) — shows `AlphaDividendsPerSubnet` and `RootAlphaDividendsPerSubnet` as separate distribution loops

## Test plan

- [x] All 7 existing tests pass (`pytest tests/ -v`)
- [x] Compared old vs new code on SN64 top-10 validators (24h) — validators with zero root TAO produce identical results, confirming no regression
- [x] Validators with significant root TAO now show corrected (higher) APYs consistent with on-chain dividend data

🤖 Generated with [Claude Code](https://claude.com/claude-code)